### PR TITLE
fix: move packagingOptions inside android block in android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,12 +27,12 @@ android {
             res.srcDirs = ['src/main/res']
         }
     }
-}
 
-packagingOptions {
-    exclude 'META-INF/LICENSE.md'
-    exclude 'META-INF/LICENSE'
-    exclude 'META-INF/NOTICE'
+    packagingOptions {
+        exclude 'META-INF/LICENSE.md'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
packagingOptions{} must be nested inside the android{} block; placing it
at the top level caused Gradle to fail with 'Could not find method
packagingOptions()' on Gradle 8.8+.

https://claude.ai/code/session_01N9c6RPsty4cxgkV2jRXPbw